### PR TITLE
Only allow simple formatting directives in paramFmt

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -164,7 +164,26 @@ func applyParamFmt(format string, isBinary bool, arg any) (string, error) {
 		format = "Bearer %s"
 	}
 
-	if strings.Count(format, "%") != 1 {
+	i := strings.IndexRune(format, '%')
+
+	switch i {
+	case -1:
+		// no format directive
+		return "", errors.New("bad fmt")
+	case len(format) - 1:
+		// last char is %
+		return "", errors.New("bad fmt")
+	}
+
+	// only permit simple (%s, %x, %X) format directives
+	switch format[i+1] {
+	case 'x', 'X', 's':
+	default:
+		return "", errors.New("bad fmt")
+	}
+
+	// only permit single format directive
+	if strings.ContainsRune(format[i+2:], '%') {
 		return "", errors.New("bad fmt")
 	}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -1,0 +1,44 @@
+package tokenizer
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestApplyFmt(t *testing.T) {
+	val, err := applyParamFmt("", true, []byte{1, 2, 3})
+	assert.NoError(t, err)
+	assert.Equal(t, "Bearer 010203", val)
+
+	val, err = applyParamFmt("", false, "123")
+	assert.NoError(t, err)
+	assert.Equal(t, "Bearer 123", val)
+
+	val, err = applyParamFmt("%x", true, []byte{1, 2, 3})
+	assert.NoError(t, err)
+	assert.Equal(t, "010203", val)
+
+	val, err = applyParamFmt("%X", true, []byte{1, 2, 3})
+	assert.NoError(t, err)
+	assert.Equal(t, "010203", val)
+
+	val, err = applyParamFmt("%s", false, "123")
+	assert.NoError(t, err)
+	assert.Equal(t, "123", val)
+
+	_, err = applyParamFmt("%d", false, "123")
+	assert.Error(t, err)
+
+	_, err = applyParamFmt("%.3s", false, "123")
+	assert.Error(t, err)
+
+	_, err = applyParamFmt("%s%s", false, "123")
+	assert.Error(t, err)
+
+	_, err = applyParamFmt("asdf%", false, "123")
+	assert.Error(t, err)
+
+	_, err = applyParamFmt("asdf", false, "123")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
String/byte format directives can truncate the input string. This could be used to brute-force secret values.