### PR TITLE
Better proxying on fly.io

### DIFF
--- a/cmd/tokenizer/log.go
+++ b/cmd/tokenizer/log.go
@@ -9,23 +9,32 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type statusCodeRecorder struct {
+type responseWriter interface {
 	http.ResponseWriter
+	http.Hijacker
+}
+
+type statusCodeRecorder struct {
+	responseWriter
 	statusCode int
 }
 
 func (w *statusCodeRecorder) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
+	w.responseWriter.WriteHeader(statusCode)
 }
 
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		scw := &statusCodeRecorder{ResponseWriter: w}
+		scw := &statusCodeRecorder{responseWriter: w.(responseWriter)}
 		queryKeys := strings.Join(maps.Keys(r.URL.Query()), ", ")
 		start := time.Now()
 
 		next.ServeHTTP(scw, r)
+
+		if scw.statusCode == 0 {
+			scw.statusCode = http.StatusOK
+		}
 
 		logrus.WithFields(logrus.Fields{
 			"method":    r.Method,

--- a/cmd/tokenizer/main.go
+++ b/cmd/tokenizer/main.go
@@ -12,6 +12,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/superfly/tokenizer"
@@ -65,6 +66,10 @@ func runServe() {
 	l, err := net.Listen("tcp", ListenAddress)
 	if err != nil {
 		logrus.WithError(err).Fatal("listen")
+	}
+
+	if len(os.Getenv("DEBUG_TCP")) != 0 {
+		l = debugListener{l}
 	}
 
 	key := os.Getenv("OPEN_KEY")
@@ -174,4 +179,57 @@ Configuration — tokenizer is configured using the following environment variab
     FILTERED_HEADERS - Comma separated list of headers to filter from client
                        requests.
 `[1:])
+}
+
+type debugListener struct {
+	net.Listener
+}
+
+func (dl debugListener) Accept() (net.Conn, error) {
+	c, err := dl.Listener.Accept()
+	if err == nil {
+		c = debugConn{c}
+	}
+	return c, err
+}
+
+type debugConn struct {
+	c net.Conn
+}
+
+func (dc debugConn) Read(b []byte) (int, error) {
+	n, err := dc.c.Read(b)
+	if err == nil {
+		fmt.Printf("<- %#v\n", string(b[:n]))
+	}
+	return n, err
+}
+
+func (dc debugConn) Write(b []byte) (int, error) {
+	fmt.Printf("-> %#v\n", string(b))
+	return dc.c.Write(b)
+}
+
+func (dc debugConn) Close() error {
+	return dc.c.Close()
+}
+
+func (dc debugConn) LocalAddr() net.Addr {
+	return dc.c.LocalAddr()
+}
+
+func (dc debugConn) RemoteAddr() net.Addr {
+	return dc.c.RemoteAddr()
+}
+
+func (dc debugConn) SetDeadline(t time.Time) error {
+	return dc.c.SetDeadline(t)
+}
+
+func (dc debugConn) SetReadDeadline(t time.Time) error {
+	return dc.c.SetReadDeadline(t)
+}
+
+func (dc debugConn) SetWriteDeadline(t time.Time) error {
+	return dc.c.SetWriteDeadline(t)
 }

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,5 @@
 kill_signal = "SIGINT"
 kill_timeout = 5
-primary_region = "ord"
 processes = []
 
 [experimental]
@@ -12,11 +11,19 @@ processes = []
   protocol = "tcp"
 
   [[services.ports]]
-    handlers = ["http"]
     port = 80
+
+  [[services.ports]]
+    handlers = ["tls"]
+    port = 443
 
   [[services.tcp_checks]]
     grace_period = "1s"
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 750
+    soft_limit = 500

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -60,16 +60,8 @@ func NewTokenizer(openKey string) *tokenizer {
 	proxy := goproxy.NewProxyHttpServer()
 	tkz := &tokenizer{ProxyHttpServer: proxy, priv: priv, pub: pub}
 
-	// fly-proxy rewrites incoming requests to not include the full URI so we
-	// have to look at the host header.
 	tkz.NonproxyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Host == "" {
-			http.Error(w, "must specify host", 400)
-			return
-		}
-		r.URL.Scheme = "http"
-		r.URL.Host = r.Host
-		tkz.ServeHTTP(w, r)
+		fmt.Fprintln(w, "I'm not that kind of server")
 	})
 
 	proxy.Tr = &http.Transport{
@@ -116,6 +108,7 @@ func (t *tokenizer) Handle(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Requ
 	}
 
 	if reqProcessors, err := t.processorsFromRequest(req); err != nil {
+		logrus.WithError(err).Warn("find processor")
 		return req, errorResponse(err)
 	} else {
 		processors = append(processors, reqProcessors...)


### PR DESCRIPTION
The "http" handler was causing headaches by rewriting the request URI. It turns out, doing TCP passthrough solves this entirely, removing the need for some hacky workarounds. Tokenizer now plays more nicely with curl.