### PR TITLE
Reject requets with no tokenized data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The client configures their HTTP library to use the tokenizer service as it's HT
 
 ```ruby
 conn = Faraday.new(
-    proxy: "http://tokenizer.flycast", 
+    proxy: "http://tokenizer.flycast",
     headers: {
         proxy_tokenizer: Base64.encode64(sealed_secret),
         proxy_authorization: "Bearer trustno1"
@@ -99,7 +99,7 @@ seal_key = ENV["TOKENIZER_PUBLIC_KEY"]
 sealed_secret = RbNaCl::Boxes::Sealed.new(seal_key).box(secret.to_json)
 
 processor_params = {
-    dst: "X-Stripe-Token", 
+    dst: "X-Stripe-Token",
     fmt: "token=%s"
 }
 
@@ -110,7 +110,7 @@ conn.get("http://api.stripe.com")
 
 ## Host allowlist
 
-If a client is fully compromised, the attacker could send encrypted secrets via tokenizer to a service that simply echoes back the request. This way, the attacker could learn the plaintext value of the secret. To mitigate against this, secrets can specify which hosts they may be used against. 
+If a client is fully compromised, the attacker could send encrypted secrets via tokenizer to a service that simply echoes back the request. This way, the attacker could learn the plaintext value of the secret. To mitigate against this, secrets can specify which hosts they may be used against.
 
 ```ruby
 secret = {
@@ -194,3 +194,4 @@ Tokenizer is configured with the following environment variables:
 - `OPEN_KEY` - The hex encoded 32 byte private key is used for decrypting secrets.
 - `LISTEN_ADDRESS` - The address (`ip:port`) to listen on.
 - `FILTERED_HEADERS` - A comma separated list of request headers to strip from client requests.
+- `OPEN_PROXY` - Setting `1` or `true` will allow requests that don't contain sealed secrets to be proxied. Such requests are blocked by default.

--- a/cmd/tokenizer/main.go
+++ b/cmd/tokenizer/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/superfly/tokenizer"
+	"golang.org/x/exp/slices"
 )
 
 // Package variables can be overridden at build time:
@@ -83,6 +84,10 @@ func runServe() {
 	if len(os.Getenv("DEBUG")) != 0 {
 		tkz.ProxyHttpServer.Verbose = true
 		tkz.ProxyHttpServer.Logger = logrus.StandardLogger()
+	}
+
+	if slices.Contains([]string{"1", "true"}, os.Getenv("OPEN_PROXY")) {
+		tkz.OpenProxy = true
 	}
 
 	server := &http.Server{Handler: tkz}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -40,6 +40,10 @@ const headerProxyTokenizer = "Proxy-Tokenizer"
 
 type tokenizer struct {
 	*goproxy.ProxyHttpServer
+
+	// OpenProxy dictates whether requests without any sealed secrets are allowed.
+	OpenProxy bool
+
 	priv *[32]byte
 	pub  *[32]byte
 }
@@ -156,7 +160,7 @@ func (t *tokenizer) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*ht
 		processors = append(processors, reqProcessors...)
 	}
 
-	if len(processors) == 0 {
+	if len(processors) == 0 && !t.OpenProxy {
 		pud.reqLog.Warn("no processors")
 		return nil, errorResponse(ErrBadRequest)
 	}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -59,7 +59,7 @@ func NewTokenizer(openKey string) *tokenizer {
 	proxy := goproxy.NewProxyHttpServer()
 	tkz := &tokenizer{ProxyHttpServer: proxy, priv: priv, pub: pub}
 
-	tkz.NonproxyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	proxy.NonproxyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "I'm not that kind of server")
 	})
 
@@ -155,6 +155,13 @@ func (t *tokenizer) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*ht
 	} else {
 		processors = append(processors, reqProcessors...)
 	}
+
+	if len(processors) == 0 {
+		pud.reqLog.Warn("no processors")
+		return nil, errorResponse(ErrBadRequest)
+	}
+
+	pud.reqLog = pud.reqLog.WithField("processors", len(processors))
 
 	for _, processor := range processors {
 		if err := processor(req); err != nil {


### PR DESCRIPTION
The only reason we don't do this already is that apps could be configured to use tokenizer for unauthenticated and authenticated requests to downstreams. Blocking requests without tokenized data might make client logic more complicated.