### PR TITLE
Transparent proxying

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -341,6 +341,14 @@ func readFlySrcKey(path string) ed25519.PublicKey {
 	return key
 }
 
+type NoAuthConfig struct{}
+
+var _ AuthConfig = (*NoAuthConfig)(nil)
+
+func (c *NoAuthConfig) AuthRequest(req *http.Request) error {
+	return nil
+}
+
 func proxyAuthorizationTokens(req *http.Request) (ret []string) {
 hdrLoop:
 	for _, hdr := range req.Header.Values(headerProxyAuthorization) {

--- a/cmd/tokenizer/main.go
+++ b/cmd/tokenizer/main.go
@@ -79,15 +79,21 @@ func runServe() {
 		os.Exit(1)
 	}
 
-	tkz := tokenizer.NewTokenizer(key)
+	opts := []tokenizer.Option{}
+
+	if hn := os.Getenv("TOKENIZER_HOSTNAMES"); hn != "" {
+		opts = append(opts, tokenizer.TokenizerHostnames(strings.Split(hn, ",")...))
+	}
+
+	if slices.Contains([]string{"1", "true"}, os.Getenv("OPEN_PROXY")) {
+		opts = append(opts, tokenizer.OpenProxy())
+	}
+
+	tkz := tokenizer.NewTokenizer(key, opts...)
 
 	if len(os.Getenv("DEBUG")) != 0 {
 		tkz.ProxyHttpServer.Verbose = true
 		tkz.ProxyHttpServer.Logger = logrus.StandardLogger()
-	}
-
-	if slices.Contains([]string{"1", "true"}, os.Getenv("OPEN_PROXY")) {
-		tkz.OpenProxy = true
 	}
 
 	server := &http.Server{Handler: tkz}

--- a/fly.toml
+++ b/fly.toml
@@ -10,12 +10,24 @@ internal_port = 8080
 processes = ["app"]
 protocol = "tcp"
 
+# tcp passthrough
 [[services.ports]]
 port = 80
 
+# tls passthrough
 [[services.ports]]
 handlers = ["tls"]
 port = 443
+
+# http via fly-proxy
+[[services.ports]]
+handlers = ["http"]
+port = 8080
+
+# https via fly-proxy
+[[services.ports]]
+handlers = ["tls", "http"]
+port = 8443
 
 [[services.tcp_checks]]
 grace_period = "1s"

--- a/secret.go
+++ b/secret.go
@@ -58,6 +58,7 @@ type wireSecret struct {
 	*MacaroonAuthConfig        `json:"macaroon_auth,omitempty"`
 	*FlyioMacaroonAuthConfig   `json:"flyio_macaroon_auth,omitempty"`
 	*FlySrcAuthConfig          `json:"fly_src_auth,omitempty"`
+	*NoAuthConfig              `json:"no_auth,omitempty"`
 	AllowHosts                 []string `json:"allowed_hosts,omitempty"`
 	AllowHostPattern           string   `json:"allowed_host_pattern,omitempty"`
 }
@@ -74,6 +75,8 @@ func (s *Secret) MarshalJSON() ([]byte, error) {
 		ws.FlyioMacaroonAuthConfig = a
 	case *FlySrcAuthConfig:
 		ws.FlySrcAuthConfig = a
+	case *NoAuthConfig:
+		ws.NoAuthConfig = a
 	default:
 		return nil, errors.New("bad auth config")
 	}
@@ -151,6 +154,10 @@ func (s *Secret) UnmarshalJSON(b []byte) error {
 	if ws.FlySrcAuthConfig != nil {
 		na += 1
 		s.AuthConfig = ws.FlySrcAuthConfig
+	}
+	if ws.NoAuthConfig != nil {
+		na += 1
+		s.AuthConfig = ws.NoAuthConfig
 	}
 	if na != 1 {
 		return errors.New("bad auth config")

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -157,6 +157,12 @@ type proxyUserData struct {
 
 // HandleConnect implements goproxy.FuncHttpsHandler
 func (t *tokenizer) HandleConnect(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+	if host == "" {
+		logrus.Warn("no host in CONNECT request")
+		ctx.Resp = errorResponse(ErrBadRequest)
+		return goproxy.RejectConnect, ""
+	}
+
 	pud := &proxyUserData{
 		connLog:      logrus.WithField("connect_host", host),
 		connectStart: time.Now(),
@@ -364,6 +370,8 @@ func errorResponse(err error) *http.Response {
 	}
 
 	return &http.Response{
+		ProtoMajor: 1,
+		ProtoMinor: 1,
 		StatusCode: status,
 		Body:       io.NopCloser(bytes.NewReader([]byte(err.Error()))),
 		Header:     make(http.Header),

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -111,7 +111,19 @@ func NewTokenizer(openKey string, opts ...Option) *tokenizer {
 		case r.Host == "":
 			http.Error(w, "must specify host", 400)
 			return
-		case hostnameMap[r.Host]:
+		}
+
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			if strings.Contains(err.Error(), "missing port in address") {
+				host = r.Host
+			} else {
+				http.Error(w, "bad host", 400)
+				return
+			}
+		}
+
+		if hostnameMap[host] {
 			http.Error(w, "circular request", 400)
 			return
 		}


### PR DESCRIPTION
There are several different methods for proxying HTTP requests. One of the most common is to send a request like this to the proxy server

```http
GET http://google.com/ HTTP/1.1
Host: google.com
```

If tokenizer is running behind an `http` fly-proxy service, this gets screwy. First of all, we have to have a static IP address configured for tokenizer. Otherwise, fly-proxy doesn't know that a request for `google.com` should go to tokenizer. Second, fly-proxy rewrites the request, removing the hostname from the URI. The request tokenizer ends up getting looks like

```http
GET / HTTP/1.1
Host: google.com
```

This no longer looks like a proxy request and our `goproxy` library doesn't know what to do with it.

This PR adds back (removed in https://github.com/superfly/tokenizer/pull/15) tokenizer's ability to receives these requests and rewrite them back into something `goproxy` knows what to do with. This allows tokenizer to run as a flycast `http` service and receive `Fly-Src` headers (see https://github.com/superfly/tokenizer/pull/24).

A threat I think I ignored when this was implemented previously though is that someone could send a request like this to tokenizer

```http
GET http://tokenizer.fly.dev/ HTTP/1.1
Host: tokenizer.fly.dev
```

Tokenizer would get sucked into a loop where it is sending requests to itself. To mitigate this, transparent proxying is only enabled if tokenizer is configured with a list of its own hostnames. It refuses to make requests to itself. I could use a second set of eyes on the logic for this.