### PR TITLE
bump the golang docker image used to build to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /go/src/github.com/superfly/tokenizer
 COPY go.mod go.sum ./


### PR DESCRIPTION
Earlier merge updated go.mod's golang version, but not the Dockerfile. This fixes the dockerfile so it can build again.