### PR TITLE
MITM to proxy HTTPS traffic

### DIFF
--- a/cmd/tokenizer/.envrc
+++ b/cmd/tokenizer/.envrc
@@ -1,2 +1,10 @@
 export LISTEN_ADDRESS="127.0.0.1:8823"
 export OPEN_KEY=0d88a36d5c41d5c3d97b929fdebf0bea57e5fb4616da88121ba972431a161cab
+
+# Allow requests without any sealed secrets
+# export OPEN_PROXY=1
+
+# HTTPS MITM - enables interception of HTTPS requests to inject credentials
+# Clients must trust this CA certificate
+# export MITM_CA_CERT_PATH=cert.pem
+# export MITM_CA_KEY_PATH=key.pem

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -134,7 +134,7 @@ func NewTokenizer(openKey string, opts ...Option) *tokenizer {
 	})
 
 	proxy.Tr = &http.Transport{
-		Dial: dialFunc(tkz.tokenizerHostnames),
+		Dial: tkz.dialFunc(),
 		// probably not necessary, but I don't want to worry about desync/smuggling
 		DisableKeepAlives: true,
 	}
@@ -398,7 +398,8 @@ func errorResponse(err error) *http.Response {
 //     our proxy can't do passthrough TLS.
 //   - It forces the upstream connection to be TLS. We want the actual upstream
 //     connection to be over TLS because security.
-func dialFunc(badAddrs []string) func(string, string) (net.Conn, error) {
+func (t *tokenizer) dialFunc() func(string, string) (net.Conn, error) {
+	badAddrs := t.tokenizerHostnames
 	_, fdaaNet, err := net.ParseCIDR("fdaa::/8")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
PoC to route requests through tokenizer server when we don't have full control over HTTP client used in the app (e.g. SDKs, etc.)