### PR TITLE
Client credentials processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,52 @@ conn.headers[:proxy_tokenizer] = "#{Base64.encode64(sealed_secret)}; #{processor
 conn.get("http://api.stripe.com")
 ```
 
+### Client credentials processor
+
+The `client_credentials_processor` implements the OAuth2 `client_credentials` grant ([RFC 6749 section 4.4](https://tools.ietf.org/html/rfc6749#section-4.4)) for machine-to-machine auth (HelpScout, and similar API platforms). It follows the same two-step sealed pattern as `jwt_processor` - see that section for the full flow description.
+
+```ruby
+secret = {
+    client_credentials_processor: {
+        client_id: "my-client-id",
+        client_secret: "my-client-secret",
+        token_url: "https://api.helpscout.net/v2/oauth2/token",
+        scopes: "mailbox.read mailbox.write"  # optional
+    },
+    bearer_auth: {
+        digest: Digest::SHA256.base64digest('trustno1')
+    },
+    allowed_hosts: ["api.helpscout.net"]
+}
+```
+
+Step 1 - Exchange the sealed client credentials for a sealed access token (send to the token endpoint through tokenizer):
+
+```ruby
+resp = conn.post("http://api.helpscout.net/v2/oauth2/token")
+sealed_access_token = JSON.parse(resp.body)["sealed_token"]
+```
+
+Step 2 - Use the sealed access token for API calls (same as `jwt_processor`):
+
+```ruby
+conn2 = Faraday.new(
+    proxy: "http://tokenizer.flycast",
+    headers: {
+        proxy_tokenizer: "#{sealed_access_token}",
+        proxy_authorization: "Bearer trustno1"
+    }
+)
+conn2.get("http://api.helpscout.net/v2/conversations")
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `client_id` | yes | OAuth2 client ID |
+| `client_secret` | yes | OAuth2 client secret (sealed, never exposed) |
+| `token_url` | yes | Token endpoint URL |
+| `scopes` | no | Space-separated OAuth2 scopes |
+
 ## Host allowlist
 
 If a client is fully compromised, the attacker could send encrypted secrets via tokenizer to a service that simply echoes back the request. This way, the attacker could learn the plaintext value of the secret. To mitigate against this, secrets can specify which hosts they may be used against.

--- a/processor.go
+++ b/processor.go
@@ -97,8 +97,9 @@ type wireProcessor struct {
 	OAuthProcessorConfig      *OAuthProcessorConfig      `json:"oauth2_processor,omitempty"`
 	OAuthBodyProcessorConfig  *OAuthBodyProcessorConfig  `json:"oauth2_body_processor,omitempty"`
 	Sigv4ProcessorConfig      *Sigv4ProcessorConfig      `json:"sigv4_processor,omitempty"`
-	JWTProcessorConfig        *JWTProcessorConfig        `json:"jwt_processor,omitempty"`
-	MultiProcessorConfig      *MultiProcessorConfig      `json:"multi_processor,omitempty"`
+	JWTProcessorConfig                  *JWTProcessorConfig                  `json:"jwt_processor,omitempty"`
+	ClientCredentialsProcessorConfig    *ClientCredentialsProcessorConfig    `json:"client_credentials_processor,omitempty"`
+	MultiProcessorConfig                *MultiProcessorConfig                `json:"multi_processor,omitempty"`
 }
 
 func newWireProcessor(p ProcessorConfig) (wireProcessor, error) {
@@ -117,6 +118,8 @@ func newWireProcessor(p ProcessorConfig) (wireProcessor, error) {
 		return wireProcessor{Sigv4ProcessorConfig: p}, nil
 	case *JWTProcessorConfig:
 		return wireProcessor{JWTProcessorConfig: p}, nil
+	case *ClientCredentialsProcessorConfig:
+		return wireProcessor{ClientCredentialsProcessorConfig: p}, nil
 	case *MultiProcessorConfig:
 		return wireProcessor{MultiProcessorConfig: p}, nil
 	default:
@@ -155,6 +158,10 @@ func (wp *wireProcessor) getProcessorConfig() (ProcessorConfig, error) {
 	if wp.JWTProcessorConfig != nil {
 		np += 1
 		p = wp.JWTProcessorConfig
+	}
+	if wp.ClientCredentialsProcessorConfig != nil {
+		np += 1
+		p = wp.ClientCredentialsProcessorConfig
 	}
 	if wp.MultiProcessorConfig != nil {
 		np += 1
@@ -703,13 +710,20 @@ func (c *JWTProcessorConfig) ResponseProcessor(params map[string]string, sctx *S
 		return nil, errors.New("JWT response processor requires a sealing context")
 	}
 
+	return sealTokenResponse(sctx), nil
+}
+
+// sealTokenResponse returns a response processor that reads a token endpoint's
+// JSON response, seals the access token into a new InjectProcessorConfig, and
+// replaces the response body with a SealedTokenResponse.
+func sealTokenResponse(sctx *SealingContext) func(*http.Response) error {
 	return func(resp *http.Response) error {
 		// Pass through non-OK responses without modification
 		if resp.StatusCode != http.StatusOK {
 			return nil
 		}
 
-		// Parse Google's token response
+		// Parse the token endpoint response
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read token response: %w", err)
@@ -763,7 +777,7 @@ func (c *JWTProcessorConfig) ResponseProcessor(params map[string]string, sctx *S
 		resp.Header.Set("Content-Type", "application/json")
 
 		return nil
-	}, nil
+	}
 }
 
 func (c *JWTProcessorConfig) StripHazmat() ProcessorConfig {
@@ -773,6 +787,66 @@ func (c *JWTProcessorConfig) StripHazmat() ProcessorConfig {
 		Subject:    c.Subject,
 		Scopes:     c.Scopes,
 		TokenURL:   c.TokenURL,
+	}
+}
+
+// ClientCredentialsProcessorConfig implements the OAuth2 client_credentials grant
+// (RFC 6749 section 4.4). Like JWTProcessorConfig, it performs a token exchange
+// and returns a sealed access token - the caller never sees the plaintext secret.
+type ClientCredentialsProcessorConfig struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	TokenURL     string `json:"token_url"`
+	Scopes       string `json:"scopes,omitempty"` // space-separated, optional
+}
+
+var _ ProcessorConfig = (*ClientCredentialsProcessorConfig)(nil)
+var _ ResponseProcessorConfig = (*ClientCredentialsProcessorConfig)(nil)
+
+func (c *ClientCredentialsProcessorConfig) Processor(params map[string]string, _ *SealingContext) (RequestProcessor, error) {
+	if c.ClientID == "" {
+		return nil, errors.New("missing client_id")
+	}
+	if c.ClientSecret == "" {
+		return nil, errors.New("missing client_secret")
+	}
+	if c.TokenURL == "" {
+		return nil, errors.New("missing token_url")
+	}
+
+	return func(r *http.Request) error {
+		vals := url.Values{
+			"grant_type":    {"client_credentials"},
+			"client_id":     {c.ClientID},
+			"client_secret": {c.ClientSecret},
+		}
+		if c.Scopes != "" {
+			vals.Set("scope", c.Scopes)
+		}
+
+		body := vals.Encode()
+		r.Body = io.NopCloser(strings.NewReader(body))
+		r.ContentLength = int64(len(body))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		return nil
+	}, nil
+}
+
+func (c *ClientCredentialsProcessorConfig) ResponseProcessor(params map[string]string, sctx *SealingContext) (func(*http.Response) error, error) {
+	if sctx == nil {
+		return nil, errors.New("client_credentials response processor requires a sealing context")
+	}
+
+	return sealTokenResponse(sctx), nil
+}
+
+func (c *ClientCredentialsProcessorConfig) StripHazmat() ProcessorConfig {
+	return &ClientCredentialsProcessorConfig{
+		ClientID:     c.ClientID,
+		ClientSecret: redactedStr,
+		TokenURL:     c.TokenURL,
+		Scopes:       c.Scopes,
 	}
 }
 

--- a/processor.go
+++ b/processor.go
@@ -91,15 +91,15 @@ type ResponseProcessorConfig interface {
 }
 
 type wireProcessor struct {
-	InjectProcessorConfig     *InjectProcessorConfig     `json:"inject_processor,omitempty"`
-	InjectHMACProcessorConfig *InjectHMACProcessorConfig `json:"inject_hmac_processor,omitempty"`
-	InjectBodyProcessorConfig *InjectBodyProcessorConfig `json:"inject_body_processor,omitempty"`
-	OAuthProcessorConfig      *OAuthProcessorConfig      `json:"oauth2_processor,omitempty"`
-	OAuthBodyProcessorConfig  *OAuthBodyProcessorConfig  `json:"oauth2_body_processor,omitempty"`
-	Sigv4ProcessorConfig      *Sigv4ProcessorConfig      `json:"sigv4_processor,omitempty"`
-	JWTProcessorConfig                  *JWTProcessorConfig                  `json:"jwt_processor,omitempty"`
-	ClientCredentialsProcessorConfig    *ClientCredentialsProcessorConfig    `json:"client_credentials_processor,omitempty"`
-	MultiProcessorConfig                *MultiProcessorConfig                `json:"multi_processor,omitempty"`
+	InjectProcessorConfig            *InjectProcessorConfig            `json:"inject_processor,omitempty"`
+	InjectHMACProcessorConfig        *InjectHMACProcessorConfig        `json:"inject_hmac_processor,omitempty"`
+	InjectBodyProcessorConfig        *InjectBodyProcessorConfig        `json:"inject_body_processor,omitempty"`
+	OAuthProcessorConfig             *OAuthProcessorConfig             `json:"oauth2_processor,omitempty"`
+	OAuthBodyProcessorConfig         *OAuthBodyProcessorConfig         `json:"oauth2_body_processor,omitempty"`
+	Sigv4ProcessorConfig             *Sigv4ProcessorConfig             `json:"sigv4_processor,omitempty"`
+	JWTProcessorConfig               *JWTProcessorConfig               `json:"jwt_processor,omitempty"`
+	ClientCredentialsProcessorConfig *ClientCredentialsProcessorConfig `json:"client_credentials_processor,omitempty"`
+	MultiProcessorConfig             *MultiProcessorConfig             `json:"multi_processor,omitempty"`
 }
 
 func newWireProcessor(p ProcessorConfig) (wireProcessor, error) {

--- a/processor_test.go
+++ b/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -918,6 +919,248 @@ func TestJWTProcessorConfig_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, "admin@example.com", jwtCfg.Subject)
 	assert.Equal(t, "https://www.googleapis.com/auth/admin.directory.user", jwtCfg.Scopes)
 	assert.Equal(t, "https://oauth2.googleapis.com/token", jwtCfg.TokenURL)
+}
+
+func TestClientCredentialsProcessorConfig_BuildsCorrectBody(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, cfg.TokenURL, nil)
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+
+	vals, err := url.ParseQuery(string(body))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "client_credentials", vals.Get("grant_type"))
+	assert.Equal(t, "my-client-id", vals.Get("client_id"))
+	assert.Equal(t, "my-client-secret", vals.Get("client_secret"))
+}
+
+func TestClientCredentialsProcessorConfig_IncludesScopeWhenSet(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+		Scopes:       "mailbox.read mailbox.write",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, cfg.TokenURL, nil)
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+
+	vals, err := url.ParseQuery(string(body))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "mailbox.read mailbox.write", vals.Get("scope"))
+}
+
+func TestClientCredentialsProcessorConfig_OmitsScopeWhenEmpty(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, cfg.TokenURL, nil)
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, string(body), "scope=")
+}
+
+func TestClientCredentialsProcessorConfig_MissingClientID(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestClientCredentialsProcessorConfig_MissingClientSecret(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID: "my-client-id",
+		TokenURL: "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestClientCredentialsProcessorConfig_MissingTokenURL(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestClientCredentialsProcessorConfig_StripHazmat(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "super-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+		Scopes:       "mailbox.read",
+	}
+
+	stripped := cfg.StripHazmat().(*ClientCredentialsProcessorConfig)
+
+	assert.Equal(t, redactedStr, stripped.ClientSecret)
+	assert.Equal(t, "my-client-id", stripped.ClientID)
+	assert.Equal(t, "https://api.helpscout.net/v2/oauth2/token", stripped.TokenURL)
+	assert.Equal(t, "mailbox.read", stripped.Scopes)
+}
+
+func TestClientCredentialsProcessorConfig_ResponseProcessor_SealsAccessToken(t *testing.T) {
+	_, pub, priv := generateTestSealKey(t)
+
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	ctx := &SealingContext{
+		AuthConfig:        NewBearerAuthConfig("trustno1"),
+		RequestValidators: []RequestValidator{AllowHosts("api.helpscout.net")},
+		SealKey:           pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, respProc)
+
+	tokenResponse := `{"access_token":"hs-access-token-xyz","expires_in":7200,"token_type":"Bearer"}`
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(tokenResponse)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.NoError(t, err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	var sealedResp SealedTokenResponse
+	err = json.Unmarshal(respBody, &sealedResp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "sealed", sealedResp.TokenType)
+	assert.True(t, sealedResp.ExpiresIn > 0 && sealedResp.ExpiresIn <= 7200)
+	assert.NotEqual(t, "", sealedResp.SealedToken)
+
+	secret, err := unsealSecret(sealedResp.SealedToken, pub, priv)
+	assert.NoError(t, err)
+
+	injector, ok := secret.ProcessorConfig.(*InjectProcessorConfig)
+	assert.True(t, ok)
+	assert.Equal(t, "hs-access-token-xyz", injector.Token)
+}
+
+func TestClientCredentialsProcessorConfig_ResponseProcessor_NonOKStatus(t *testing.T) {
+	_, pub, _ := generateTestSealKey(t)
+
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	ctx := &SealingContext{
+		AuthConfig: NewBearerAuthConfig("trustno1"),
+		SealKey:    pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: 401,
+		Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_client"}`)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(body), "invalid_client")
+}
+
+func TestClientCredentialsProcessorConfig_ResponseProcessor_NilContext(t *testing.T) {
+	cfg := &ClientCredentialsProcessorConfig{
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+	}
+
+	_, err := cfg.ResponseProcessor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestClientCredentialsProcessorConfig_JSONRoundTrip(t *testing.T) {
+	original := &Secret{
+		AuthConfig: NewBearerAuthConfig("trustno1"),
+		ProcessorConfig: &ClientCredentialsProcessorConfig{
+			ClientID:     "my-client-id",
+			ClientSecret: "my-client-secret",
+			TokenURL:     "https://api.helpscout.net/v2/oauth2/token",
+			Scopes:       "mailbox.read mailbox.write",
+		},
+		RequestValidators: []RequestValidator{AllowHosts("api.helpscout.net")},
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(data), "client_credentials_processor")
+
+	var restored Secret
+	err = json.Unmarshal(data, &restored)
+	assert.NoError(t, err)
+
+	ccCfg, ok := restored.ProcessorConfig.(*ClientCredentialsProcessorConfig)
+	assert.True(t, ok)
+	assert.Equal(t, "my-client-id", ccCfg.ClientID)
+	assert.Equal(t, "my-client-secret", ccCfg.ClientSecret)
+	assert.Equal(t, "https://api.helpscout.net/v2/oauth2/token", ccCfg.TokenURL)
+	assert.Equal(t, "mailbox.read mailbox.write", ccCfg.Scopes)
 }
 
 // unsealSecret is a test helper that decrypts a sealed secret.


### PR DESCRIPTION
HelpScout (and other API platforms) use the OAuth2 client_credentials grant for M2M auth, which tokenizer had no native support for. Without it, the client secret had to be stored and managed outside tokenizer, defeating the point, or the token had to be continually refreshed.

Implements RFC 6749 §4.4 following the same two-step sealed pattern as jwt_processor - the caller never sees the plaintext secret or access token.
Also extracts a shared sealTokenResponse helper so JWT and client_credentials don't duplicate the response-sealing logic.