### PR TITLE
Add GitHub App processor for installation token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,59 @@ conn2.get("http://api.helpscout.net/v2/conversations")
 | `token_url` | yes | Token endpoint URL |
 | `scopes` | no | Space-separated OAuth2 scopes |
 
+### GitHub App processor
+
+The `github_app_processor` authenticates as a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation). It follows the same two-step sealed pattern as `jwt_processor`, but with GitHub's non-standard flow: the JWT goes in the `Authorization` header (not a form body), the request body is empty, and the installation ID lives in the URL path. GitHub requires RSA keys signed with RS256; other key types are rejected.
+
+```ruby
+secret = {
+    github_app_processor: {
+        private_key: File.read("github-app-key.pem"),
+        app_id: "123456",
+        installation_id: "78901234",
+        # token_url: "https://api.github.com/app/installations/{installation_id}/access_tokens"  # default
+    },
+    bearer_auth: {
+        digest: Digest::SHA256.base64digest('trustno1')
+    },
+    allowed_hosts: ["api.github.com"]
+}
+```
+
+Step 1 - Exchange the sealed App key for a sealed installation token. POST to any path on `api.github.com` through tokenizer - the processor rewrites the path using the sealed `installation_id`:
+
+```ruby
+resp = conn.post("http://api.github.com/")
+sealed_installation_token = JSON.parse(resp.body)["sealed_token"]
+```
+
+The response body is replaced with:
+```json
+{"sealed_token": "<base64 sealed InjectProcessor>", "expires_in": 3540, "token_type": "sealed"}
+```
+
+Installation tokens expire after one hour. Repeat step 1 before expiry.
+
+Step 2 - Use the sealed installation token for API calls. Tokenizer injects `Authorization: token <installation_token>` and enforces that the token is only usable against `api.github.com`:
+
+```ruby
+conn2 = Faraday.new(
+    proxy: "http://tokenizer.flycast",
+    headers: {
+        proxy_tokenizer: "#{sealed_installation_token}",
+        proxy_authorization: "Bearer trustno1"
+    }
+)
+conn2.get("http://api.github.com/installation/repositories")
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `private_key` | yes | PEM-encoded RSA private key (sealed, never exposed) |
+| `app_id` | yes | GitHub App ID, used as the JWT `iss` claim |
+| `installation_id` | yes | Installation ID, substituted into `token_url` |
+| `token_url` | no | Token URL template; `{installation_id}` is substituted. Override for GitHub Enterprise. |
+
 ## Host allowlist
 
 If a client is fully compromised, the attacker could send encrypted secrets via tokenizer to a service that simply echoes back the request. This way, the attacker could learn the plaintext value of the secret. To mitigate against this, secrets can specify which hosts they may be used against.

--- a/processor.go
+++ b/processor.go
@@ -99,6 +99,7 @@ type wireProcessor struct {
 	Sigv4ProcessorConfig             *Sigv4ProcessorConfig             `json:"sigv4_processor,omitempty"`
 	JWTProcessorConfig               *JWTProcessorConfig               `json:"jwt_processor,omitempty"`
 	ClientCredentialsProcessorConfig *ClientCredentialsProcessorConfig `json:"client_credentials_processor,omitempty"`
+	GitHubAppProcessorConfig         *GitHubAppProcessorConfig         `json:"github_app_processor,omitempty"`
 	MultiProcessorConfig             *MultiProcessorConfig             `json:"multi_processor,omitempty"`
 }
 
@@ -120,6 +121,8 @@ func newWireProcessor(p ProcessorConfig) (wireProcessor, error) {
 		return wireProcessor{JWTProcessorConfig: p}, nil
 	case *ClientCredentialsProcessorConfig:
 		return wireProcessor{ClientCredentialsProcessorConfig: p}, nil
+	case *GitHubAppProcessorConfig:
+		return wireProcessor{GitHubAppProcessorConfig: p}, nil
 	case *MultiProcessorConfig:
 		return wireProcessor{MultiProcessorConfig: p}, nil
 	default:
@@ -162,6 +165,10 @@ func (wp *wireProcessor) getProcessorConfig() (ProcessorConfig, error) {
 	if wp.ClientCredentialsProcessorConfig != nil {
 		np += 1
 		p = wp.ClientCredentialsProcessorConfig
+	}
+	if wp.GitHubAppProcessorConfig != nil {
+		np += 1
+		p = wp.GitHubAppProcessorConfig
 	}
 	if wp.MultiProcessorConfig != nil {
 		np += 1
@@ -848,6 +855,188 @@ func (c *ClientCredentialsProcessorConfig) StripHazmat() ProcessorConfig {
 		ClientSecret: redactedStr,
 		TokenURL:     c.TokenURL,
 		Scopes:       c.Scopes,
+	}
+}
+
+const (
+	defaultGitHubAppTokenURL    = "https://api.github.com/app/installations/{installation_id}/access_tokens"
+	githubAppHost               = "api.github.com"
+	githubAppInstallationIDTmpl = "{installation_id}"
+)
+
+// GitHubAppProcessorConfig signs a JWT for a GitHub App and exchanges it for
+// an installation access token. GitHub Apps use a bespoke flow (distinct from
+// RFC 7523): the JWT is placed in the Authorization header (not a form body),
+// the request body is empty, and the installation ID is in the URL path.
+// GitHub requires RSA keys signed with RS256; other key types are rejected.
+//
+// Like JWTProcessorConfig, this processor also transforms the response: it
+// parses GitHub's {"token": "ghs_...", "expires_at": "..."} reply, seals the
+// installation token into a new InjectProcessorConfig (pinned to
+// api.github.com with a `token %s` Authorization format), and replaces the
+// response body with a SealedTokenResponse. The private key, the signed JWT,
+// and the installation token are never visible to the caller.
+type GitHubAppProcessorConfig struct {
+	PrivateKey     []byte `json:"private_key"`     // PEM-encoded RSA private key
+	AppID          string `json:"app_id"`          // GitHub App ID (JWT "iss")
+	InstallationID string `json:"installation_id"` // substituted into TokenURL
+	TokenURL       string `json:"token_url"`       // template; default is GitHub's public endpoint
+}
+
+var _ ProcessorConfig = (*GitHubAppProcessorConfig)(nil)
+var _ ResponseProcessorConfig = (*GitHubAppProcessorConfig)(nil)
+
+func (c *GitHubAppProcessorConfig) tokenURL() string {
+	tmpl := c.TokenURL
+	if tmpl == "" {
+		tmpl = defaultGitHubAppTokenURL
+	}
+	return strings.ReplaceAll(tmpl, githubAppInstallationIDTmpl, c.InstallationID)
+}
+
+func (c *GitHubAppProcessorConfig) Processor(params map[string]string, _ *SealingContext) (RequestProcessor, error) {
+	if len(c.PrivateKey) == 0 {
+		return nil, errors.New("missing private key")
+	}
+	if c.AppID == "" {
+		return nil, errors.New("missing app_id")
+	}
+	if c.InstallationID == "" {
+		return nil, errors.New("missing installation_id")
+	}
+
+	block, _ := pem.Decode(c.PrivateKey)
+	if block == nil {
+		return nil, errors.New("invalid PEM-encoded private key")
+	}
+
+	var rsaKey *rsa.PrivateKey
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		rsaKey = k
+	} else if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		if rk, ok := k.(*rsa.PrivateKey); ok {
+			rsaKey = rk
+		} else {
+			return nil, errors.New("GitHub App requires an RSA private key")
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported private key format: %w", err)
+	}
+
+	target, err := url.Parse(c.tokenURL())
+	if err != nil {
+		return nil, fmt.Errorf("invalid token_url: %w", err)
+	}
+	if target.Path == "" {
+		return nil, errors.New("token_url must include a path")
+	}
+
+	return func(r *http.Request) error {
+		now := time.Now()
+		claims := jwt.MapClaims{
+			"iss": c.AppID,
+			"iat": now.Unix(),
+			"exp": now.Add(10 * time.Minute).Unix(),
+		}
+
+		signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(rsaKey)
+		if err != nil {
+			return fmt.Errorf("failed to sign JWT: %w", err)
+		}
+
+		r.Header.Set("Authorization", "Bearer "+signed)
+		r.Header.Set("Accept", "application/vnd.github+json")
+		r.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		r.URL.Path = target.Path
+		r.URL.RawPath = target.RawPath
+
+		r.Body = http.NoBody
+		r.ContentLength = 0
+		r.Header.Del("Content-Type")
+
+		return nil
+	}, nil
+}
+
+func (c *GitHubAppProcessorConfig) ResponseProcessor(_ map[string]string, sctx *SealingContext) (func(*http.Response) error, error) {
+	if sctx == nil {
+		return nil, errors.New("github_app response processor requires a sealing context")
+	}
+
+	return func(resp *http.Response) error {
+		if resp.StatusCode != http.StatusOK {
+			return nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read token response: %w", err)
+		}
+
+		var tokenResp struct {
+			Token     string    `json:"token"`
+			ExpiresAt time.Time `json:"expires_at"`
+		}
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			return fmt.Errorf("failed to parse token response: %w", err)
+		}
+
+		if tokenResp.Token == "" {
+			return errors.New("token response missing token")
+		}
+
+		// Installation tokens can only be replayed against api.github.com. Pin
+		// the sealed secret even if the outer secret didn't.
+		newSecret := &Secret{
+			AuthConfig: sctx.AuthConfig,
+			ProcessorConfig: &InjectProcessorConfig{
+				Token:        tokenResp.Token,
+				FmtProcessor: FmtProcessor{Fmt: "token %s"},
+			},
+			RequestValidators: []RequestValidator{AllowHosts(githubAppHost)},
+		}
+
+		sealed, err := newSecret.sealRaw(sctx.SealKey)
+		if err != nil {
+			return fmt.Errorf("failed to seal installation token: %w", err)
+		}
+
+		expiresIn := 3600
+		if !tokenResp.ExpiresAt.IsZero() {
+			if secs := int(time.Until(tokenResp.ExpiresAt).Seconds()); secs > 0 {
+				expiresIn = secs
+			}
+		}
+		if expiresIn > 60 {
+			expiresIn -= 60
+		}
+
+		sealedResp := SealedTokenResponse{
+			SealedToken: sealed,
+			ExpiresIn:   expiresIn,
+			TokenType:   "sealed",
+		}
+
+		respJSON, err := json.Marshal(sealedResp)
+		if err != nil {
+			return fmt.Errorf("failed to marshal sealed response: %w", err)
+		}
+
+		resp.Body = io.NopCloser(bytes.NewReader(respJSON))
+		resp.ContentLength = int64(len(respJSON))
+		resp.Header.Set("Content-Type", "application/json")
+
+		return nil
+	}, nil
+}
+
+func (c *GitHubAppProcessorConfig) StripHazmat() ProcessorConfig {
+	return &GitHubAppProcessorConfig{
+		PrivateKey:     redactedBase64,
+		AppID:          c.AppID,
+		InstallationID: c.InstallationID,
+		TokenURL:       c.TokenURL,
 	}
 }
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -1163,6 +1163,415 @@ func TestClientCredentialsProcessorConfig_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, "mailbox.read mailbox.write", ccCfg.Scopes)
 }
 
+func TestGitHubAppProcessorConfig_Processor_BuildsValidJWT(t *testing.T) {
+	rsaKey, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.github.com/", nil)
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	// Verify GitHub-required headers
+	authHeader := req.Header.Get("Authorization")
+	assert.True(t, strings.HasPrefix(authHeader, "Bearer "))
+	assert.Equal(t, "application/vnd.github+json", req.Header.Get("Accept"))
+	assert.Equal(t, "2022-11-28", req.Header.Get("X-GitHub-Api-Version"))
+
+	// URL path is rewritten to the installation access_tokens endpoint
+	assert.Equal(t, "/app/installations/789012/access_tokens", req.URL.Path)
+
+	// Request body is empty (GitHub requires no body)
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(body))
+	}
+	assert.Equal(t, int64(0), req.ContentLength)
+
+	// Parse and verify the JWT
+	jwtStr := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := jwt.Parse(jwtStr, func(token *jwt.Token) (interface{}, error) {
+		assert.Equal(t, "RS256", token.Method.Alg())
+		return &rsaKey.PublicKey, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, token.Valid)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+	assert.Equal(t, "123456", claims["iss"])
+
+	// exp should be ~10min after iat (GitHub's max)
+	iat, ok := claims["iat"].(float64)
+	assert.True(t, ok)
+	exp, ok := claims["exp"].(float64)
+	assert.True(t, ok)
+	diff := exp - iat
+	assert.True(t, diff >= 599 && diff <= 601)
+	assert.True(t, time.Unix(int64(iat), 0).Before(time.Now().Add(time.Minute)))
+
+	// GitHub JWTs must not include aud, scope, or sub
+	_, hasAud := claims["aud"]
+	assert.False(t, hasAud)
+	_, hasScope := claims["scope"]
+	assert.False(t, hasScope)
+	_, hasSub := claims["sub"]
+	assert.False(t, hasSub)
+}
+
+func TestGitHubAppProcessorConfig_Processor_CustomTokenURL(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+		TokenURL:       "https://github.enterprise.example/api/v3/app/installations/{installation_id}/access_tokens",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "https://github.enterprise.example/", nil)
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "/api/v3/app/installations/789012/access_tokens", req.URL.Path)
+}
+
+func TestGitHubAppProcessorConfig_Processor_MissingPrivateKey(t *testing.T) {
+	cfg := &GitHubAppProcessorConfig{
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_Processor_InvalidPrivateKey(t *testing.T) {
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     []byte("not-a-real-key"),
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_Processor_MissingAppID(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		InstallationID: "789012",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_Processor_MissingInstallationID(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey: pemBytes,
+		AppID:      "123456",
+	}
+
+	_, err := cfg.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_Processor_RejectsNonRSAKey(t *testing.T) {
+	// GitHub Apps require RSA keys (RS256). Reject ECDSA and Ed25519.
+	_, ecPEM := generateTestECKey(t)
+	cfgEC := &GitHubAppProcessorConfig{
+		PrivateKey:     ecPEM,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+	_, err := cfgEC.Processor(nil, nil)
+	assert.Error(t, err)
+
+	_, _, ed25519PEM := generateTestEd25519Key(t)
+	cfgEd := &GitHubAppProcessorConfig{
+		PrivateKey:     ed25519PEM,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+	_, err = cfgEd.Processor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_Processor_ClearsExistingBody(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	proc, err := cfg.Processor(nil, nil)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.github.com/", strings.NewReader("stale body"))
+	assert.NoError(t, err)
+
+	err = proc(req)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(body))
+	assert.Equal(t, int64(0), req.ContentLength)
+}
+
+func TestGitHubAppProcessorConfig_StripHazmat(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+		TokenURL:       "https://api.github.com/app/installations/{installation_id}/access_tokens",
+	}
+
+	stripped := cfg.StripHazmat().(*GitHubAppProcessorConfig)
+
+	assert.NotEqual(t, pemBytes, stripped.PrivateKey)
+	assert.Equal(t, redactedBase64, stripped.PrivateKey)
+
+	assert.Equal(t, "123456", stripped.AppID)
+	assert.Equal(t, "789012", stripped.InstallationID)
+	assert.Equal(t, "https://api.github.com/app/installations/{installation_id}/access_tokens", stripped.TokenURL)
+}
+
+func TestGitHubAppProcessorConfig_ResponseProcessor_SealsInstallationToken(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+	_, pub, priv := generateTestSealKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	// Outer secret is authenticated with bearer auth and pinned to api.github.com
+	// for the exchange itself. The sealed installation token should also be
+	// pinned to api.github.com regardless of what the outer secret allowed.
+	ctx := &SealingContext{
+		AuthConfig:        NewBearerAuthConfig("trustno1"),
+		RequestValidators: []RequestValidator{AllowHosts("api.github.com")},
+		SealKey:           pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+	assert.NotEqual(t, nil, respProc)
+
+	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	githubResp := fmt.Sprintf(`{"token":"ghs_installationtokenXYZ","expires_at":%q,"permissions":{"contents":"read"}}`, expiresAt)
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(githubResp)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.NoError(t, err)
+
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	var sealedResp SealedTokenResponse
+	err = json.Unmarshal(respBody, &sealedResp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "sealed", sealedResp.TokenType)
+	assert.True(t, sealedResp.ExpiresIn > 0 && sealedResp.ExpiresIn <= 3600)
+	assert.NotEqual(t, "", sealedResp.SealedToken)
+
+	secret, err := unsealSecret(sealedResp.SealedToken, pub, priv)
+	assert.NoError(t, err)
+
+	injector, ok := secret.ProcessorConfig.(*InjectProcessorConfig)
+	assert.True(t, ok)
+	assert.Equal(t, "ghs_installationtokenXYZ", injector.Token)
+	// GitHub's legacy auth header uses `token <value>` (still accepted alongside Bearer).
+	assert.Equal(t, "token %s", injector.FmtProcessor.Fmt)
+
+	// Auth and host pinning forwarded into the sealed secret
+	secretJSON, err := json.Marshal(secret)
+	assert.NoError(t, err)
+	assert.Contains(t, string(secretJSON), "bearer_auth")
+	assert.Contains(t, string(secretJSON), "api.github.com")
+}
+
+func TestGitHubAppProcessorConfig_ResponseProcessor_PinsToAPIHostWithoutOuterValidator(t *testing.T) {
+	// Even if the outer sealed secret has no host pin, the sealed installation
+	// token must be pinned to api.github.com so it can't be replayed elsewhere.
+	_, pemBytes := generateTestRSAKey(t)
+	_, pub, priv := generateTestSealKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	ctx := &SealingContext{
+		AuthConfig:        NewBearerAuthConfig("trustno1"),
+		RequestValidators: nil,
+		SealKey:           pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+
+	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	githubResp := fmt.Sprintf(`{"token":"ghs_abc","expires_at":%q}`, expiresAt)
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(githubResp)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.NoError(t, err)
+
+	var sealedResp SealedTokenResponse
+	respBody, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	err = json.Unmarshal(respBody, &sealedResp)
+	assert.NoError(t, err)
+
+	secret, err := unsealSecret(sealedResp.SealedToken, pub, priv)
+	assert.NoError(t, err)
+
+	secretJSON, err := json.Marshal(secret)
+	assert.NoError(t, err)
+	assert.Contains(t, string(secretJSON), "api.github.com")
+}
+
+func TestGitHubAppProcessorConfig_ResponseProcessor_MissingToken(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+	_, pub, _ := generateTestSealKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	ctx := &SealingContext{
+		AuthConfig: NewBearerAuthConfig("trustno1"),
+		SealKey:    pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"not_token":"nope"}`)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_ResponseProcessor_NonOKStatus(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+	_, pub, _ := generateTestSealKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	ctx := &SealingContext{
+		AuthConfig: NewBearerAuthConfig("trustno1"),
+		SealKey:    pub,
+	}
+
+	respProc, err := cfg.ResponseProcessor(nil, ctx)
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: 401,
+		Body:       io.NopCloser(strings.NewReader(`{"message":"Bad credentials"}`)),
+		Header:     make(http.Header),
+	}
+
+	err = respProc(resp)
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(body), "Bad credentials")
+}
+
+func TestGitHubAppProcessorConfig_ResponseProcessor_NilContext(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	cfg := &GitHubAppProcessorConfig{
+		PrivateKey:     pemBytes,
+		AppID:          "123456",
+		InstallationID: "789012",
+	}
+
+	_, err := cfg.ResponseProcessor(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestGitHubAppProcessorConfig_JSONRoundTrip(t *testing.T) {
+	_, pemBytes := generateTestRSAKey(t)
+
+	original := &Secret{
+		AuthConfig: NewBearerAuthConfig("trustno1"),
+		ProcessorConfig: &GitHubAppProcessorConfig{
+			PrivateKey:     pemBytes,
+			AppID:          "123456",
+			InstallationID: "789012",
+			TokenURL:       "https://api.github.com/app/installations/{installation_id}/access_tokens",
+		},
+		RequestValidators: []RequestValidator{AllowHosts("api.github.com")},
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(data), "github_app_processor")
+
+	var restored Secret
+	err = json.Unmarshal(data, &restored)
+	assert.NoError(t, err)
+
+	ghCfg, ok := restored.ProcessorConfig.(*GitHubAppProcessorConfig)
+	assert.True(t, ok)
+	assert.Equal(t, pemBytes, ghCfg.PrivateKey)
+	assert.Equal(t, "123456", ghCfg.AppID)
+	assert.Equal(t, "789012", ghCfg.InstallationID)
+	assert.Equal(t, "https://api.github.com/app/installations/{installation_id}/access_tokens", ghCfg.TokenURL)
+}
+
 // unsealSecret is a test helper that decrypts a sealed secret.
 func unsealSecret(sealed string, pub *[32]byte, priv *[32]byte) (*Secret, error) {
 	ctSecret, err := base64.StdEncoding.DecodeString(sealed)


### PR DESCRIPTION
GitHub Apps use a bespoke flow (JWT in the Authorization header, not an OAuth2 form body) that JWTProcessorConfig can't express. This adds GitHubAppProcessorConfig following the same sealed two-step pattern: sign a 10-minute RS256 JWT, exchange it for an installation token, and return a SealedTokenResponse whose inner InjectProcessorConfig is pinned to api.github.com with a "token %s" Authorization format - so neither the private key nor the installation token is ever plaintext outside tokenizer's process memory.