### PR TITLE
Fix GitHub App response processor to match GitHub's 201 status

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -965,7 +965,9 @@ func (c *GitHubAppProcessorConfig) ResponseProcessor(_ map[string]string, sctx *
 	}
 
 	return func(resp *http.Response) error {
-		if resp.StatusCode != http.StatusOK {
+		// GitHub's installation token endpoint returns 201 Created on success.
+		// https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
+		if resp.StatusCode != http.StatusCreated {
 			return nil
 		}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -1387,7 +1387,7 @@ func TestGitHubAppProcessorConfig_ResponseProcessor_SealsInstallationToken(t *te
 	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	githubResp := fmt.Sprintf(`{"token":"ghs_installationtokenXYZ","expires_at":%q,"permissions":{"contents":"read"}}`, expiresAt)
 	resp := &http.Response{
-		StatusCode: 200,
+		StatusCode: 201,
 		Body:       io.NopCloser(strings.NewReader(githubResp)),
 		Header:     make(http.Header),
 	}
@@ -1446,7 +1446,7 @@ func TestGitHubAppProcessorConfig_ResponseProcessor_PinsToAPIHostWithoutOuterVal
 	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	githubResp := fmt.Sprintf(`{"token":"ghs_abc","expires_at":%q}`, expiresAt)
 	resp := &http.Response{
-		StatusCode: 200,
+		StatusCode: 201,
 		Body:       io.NopCloser(strings.NewReader(githubResp)),
 		Header:     make(http.Header),
 	}
@@ -1487,7 +1487,7 @@ func TestGitHubAppProcessorConfig_ResponseProcessor_MissingToken(t *testing.T) {
 	assert.NoError(t, err)
 
 	resp := &http.Response{
-		StatusCode: 200,
+		StatusCode: 201,
 		Body:       io.NopCloser(strings.NewReader(`{"not_token":"nope"}`)),
 		Header:     make(http.Header),
 	}


### PR DESCRIPTION
GitHub's installation token endpoint returns 201 Created on success, not 200 OK. The response processor was checking for 200 and silently passing the unwrapped response (containing the plaintext installation token) through to the caller, defeating the sealing protection.

Tests still asserted 200 for the GitHub fixtures, so they passed despite the mismatch with the real API.

Ref: https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app